### PR TITLE
Fixed null reference error when registering a new account

### DIFF
--- a/Source/PlayFabSDK/Shared/Internal/PlayFabHttp/PlayFabWWW.cs
+++ b/Source/PlayFabSDK/Shared/Internal/PlayFabHttp/PlayFabWWW.cs
@@ -114,13 +114,12 @@ namespace PlayFab.Internal
                         }
                         else if (regRes != null)
                         {
-                            userSettings = res.SettingsForUser;
+                            userSettings = regRes.SettingsForUser;
                             AuthKey = regRes.SessionTicket;
                         }
 
                         if (userSettings != null)
                         {
-                            AuthKey = res.SessionTicket;
                             #region Track IDFA
 
 #if !DISABLE_IDFA


### PR DESCRIPTION
Seems like there's a typo where the user settings were supposed to be loaded from the registration result. It's instead loaded from the login result, which has already been proven to be null due to the previous if-statement.
If `res` is null due to the result being a `RegisterPlayFabUserResult` instead of a `LoginResult` then the second time `AuthKey` is assigned, it will cause another null reference error. The assignment is redundant since one of the previous if-statements would have already assigned it.