### PR TITLE
Fixed conversion compiler error when using Server API.

### DIFF
--- a/Source/PlayFabSDK/Server/PlayFabServerModels.cs
+++ b/Source/PlayFabSDK/Server/PlayFabServerModels.cs
@@ -641,7 +641,7 @@ namespace PlayFab.ServerModels
     }
 
     [Serializable]
-    public class EvaluateRandomResultTableRequest : PlayFabResultCommon
+    public class EvaluateRandomResultTableRequest : PlayFabRequestCommon
     {
 
         /// <summary>


### PR DESCRIPTION
This looks like a simple typo or copy/paste mistake where a Request type is improperly deriving from a Result type. It prevents the latest master branch from being compiled.