### PR TITLE
Fix ambiguous reference

### DIFF
--- a/Source/PlayFabSDK/Shared/Internal/PlayFabHttp/PlayFabWWW.cs
+++ b/Source/PlayFabSDK/Shared/Internal/PlayFabHttp/PlayFabWWW.cs
@@ -95,7 +95,7 @@ namespace PlayFab.Internal
 
                 using (var stream = new MemoryStream())
                 {
-                    using (var zipstream = new GZipStream(stream, CompressionMode.Compress, CompressionLevel.BestCompression))
+                    using (var zipstream = new GZipStream(stream, CompressionMode.Compress, Ionic.Zlib.CompressionLevel.BestCompression))
                     {
                         zipstream.Write(reqContainer.Payload, 0, reqContainer.Payload.Length);
                     }


### PR DESCRIPTION
Unity version: 2018.3.0b5
Platform: Mac Standalone
Message: error CS0104: 'CompressionLevel' is an ambiguous reference between 'Ionic.Zlib.CompressionLevel' and 'UnityEngine.CompressionLevel'