### PR TITLE
Fix IL2CPP stripping issue

### DIFF
--- a/Source/PlayFabSDK/link.xml
+++ b/Source/PlayFabSDK/link.xml
@@ -15,4 +15,7 @@
     <namespace fullname="Mono.Security.Protocol.Tls" preserve="all"/>
     <namespace fullname="Mono.Security.X509" preserve="all"/>
   </assembly>
+  <assembly fullname="Assembly-CSharp">
+    <namespace fullname="PlayFab.*" preserve="all"/>
+  </assembly>
 </linker>


### PR DESCRIPTION
PlayFab code gets stripped if IL2CPP stripping level is set to Medium or High. This prevents the PlayFab code from being stripped by IL2CPP.