### PR TITLE
Unity libCurl update fix

### DIFF
--- a/ExampleMacProject/Assets/PlayFabSDK/Shared/Internal/PlayFabHttp/PlayFabUnityHttp.cs
+++ b/ExampleMacProject/Assets/PlayFabSDK/Shared/Internal/PlayFabHttp/PlayFabUnityHttp.cs
@@ -97,7 +97,7 @@ namespace PlayFab.Internal
             CallRequestContainer reqContainer = (CallRequestContainer)reqContainerObj;
             reqContainer.RequestHeaders["Content-Type"] = "application/json";
 
-#if !UNITY_WSA && !UNITY_WP8 && !UNITY_WEBGL
+#if !UNITY_WSA && !UNITY_WP8 && !UNITY_WEBGL &&!UNITY_EDITOR_WIN &&!UNITY_STANDALONE_WIN &&!UNITY_WSA_10_0 // Unity has removed compression in Windows (will be added again at a later point)
             if (PlayFabSettings.CompressApiData)
             {
                 reqContainer.RequestHeaders["Content-Encoding"] = "GZIP";

--- a/ExampleTestProject/Assets/PlayFabSDK/Shared/Internal/PlayFabHttp/PlayFabUnityHttp.cs
+++ b/ExampleTestProject/Assets/PlayFabSDK/Shared/Internal/PlayFabHttp/PlayFabUnityHttp.cs
@@ -97,7 +97,7 @@ namespace PlayFab.Internal
             CallRequestContainer reqContainer = (CallRequestContainer)reqContainerObj;
             reqContainer.RequestHeaders["Content-Type"] = "application/json";
 
-#if !UNITY_WSA && !UNITY_WP8 && !UNITY_WEBGL
+#if !UNITY_WSA && !UNITY_WP8 && !UNITY_WEBGL &&!UNITY_EDITOR_WIN &&!UNITY_STANDALONE_WIN &&!UNITY_WSA_10_0 // Unity has removed compression in Windows (will be added again at a later point)
             if (PlayFabSettings.CompressApiData)
             {
                 reqContainer.RequestHeaders["Content-Encoding"] = "GZIP";


### PR DESCRIPTION
Unity has completely removed support for compression in UnityWebRequest under Windows. This changed has now arrived in LTS.
New users see Playfab failing with the default settings and they can't use it.
This fix skips compression for any Windows platform (even the editor is affected). Not much else you can do, until Unity adds support again.