### PR TITLE
Update PlayFabClientModels.cs

### DIFF
--- a/ExampleTestProject/Assets/PlayFabSDK/Client/PlayFabClientModels.cs
+++ b/ExampleTestProject/Assets/PlayFabSDK/Client/PlayFabClientModels.cs
@@ -4265,6 +4265,12 @@ namespace PlayFab.ClientModels
         /// title has been selected.
         /// </summary>
         public string TitleId;
+        /// <summary>
+        /// The API allows for passing of the google access token for login
+        /// https://docs.microsoft.com/en-us/gaming/playfab/features/authentication/platform-specific-authentication/google-html5#testing-using-an-access-token
+        /// Simply adding this string allows for it to be passed to the method "LoginWithGoogleAccount"
+        /// <summary>
+        public string AccessToken;
     }
 
     /// <summary>


### PR DESCRIPTION
Add "AccessToken" string to the LoginWithGoogleAccountRequest class
This will allow the google access token to be passed to the method LoginWithGoogleAccount
This is supported by the API and works
https://docs.microsoft.com/en-us/gaming/playfab/features/authentication/platform-specific-authentication/google-html5#testing-using-an-access-token

An example of usage -

public void LoginUserViaGoogle(string token, Action<bool> successCallback)
        {
            LoginWithGoogleAccountRequest request = new LoginWithGoogleAccountRequest();
            request.TitleId = PlayFabSettings.TitleId;
            request.CreateAccount = true;
            request.AccessToken = token;
            PlayFabClientAPI.LoginWithGoogleAccount(request, (LoginResult result) =>
            {
                successCallback(result.NewlyCreated);
            }, (PlayFabError error) => { GenericPlayFabErrorHandler(error); });
        }