### PR TITLE
A Native Collection has not been disposed, resulting in a memory leak (PlayFabUnityHttp.cs)

### DIFF
--- a/ExampleTestProject/Assets/PlayFabSDK/Shared/Internal/PlayFabHttp/PlayFabUnityHttp.cs
+++ b/ExampleTestProject/Assets/PlayFabSDK/Shared/Internal/PlayFabHttp/PlayFabUnityHttp.cs
@@ -114,7 +114,7 @@ namespace PlayFab.Internal
             var startTime = DateTime.UtcNow;
 #endif
 
-            var www = new UnityWebRequest(reqContainer.FullUrl)
+            using var www = new UnityWebRequest(reqContainer.FullUrl)
             {
                 uploadHandler = new UploadHandlerRaw(reqContainer.Payload),
                 downloadHandler = new DownloadHandlerBuffer(),


### PR DESCRIPTION
Fixes:

```
A Native Collection has not been disposed, resulting in a memory leak. Allocated from:
Unity.Collections.NativeArray`1:.ctor(Byte[], Allocator)
UnityEngine.Networking.UploadHandlerRaw:.ctor(Byte[])
PlayFab.Internal.<Post>d__12:MoveNext() (at Assets\Libs\PlayFabSDK\Shared\Internal\PlayFabHttp\PlayFabUnityHttp.cs:116)
UnityEngine.SetupCoroutine:InvokeMoveNext(IEnumerator, IntPtr)
UnityEngine.MonoBehaviour:StartCoroutineManaged2(MonoBehaviour, IEnumerator)
UnityEngine.MonoBehaviour:StartCoroutine(IEnumerator)
PlayFab.Internal.PlayFabUnityHttp:MakeApiCall(Object) (at Assets\Libs\PlayFabSDK\Shared\Internal\PlayFabHttp\PlayFabUnityHttp.cs:106)
PlayFab.Internal.PlayFabHttp:_MakeApiCall(String, String, PlayFabRequestCommon, AuthType, Action`1, Action`1, Object, Dictionary`2, Boolean, PlayFabAuthenticationContext, PlayFabApiSettings, IPlayFabInstanceApi) (at Assets\Libs\PlayFabSDK\Shared\Internal\PlayFabHttp\PlayFabHTTP.cs:228)
PlayFab.Internal.PlayFabHttp:MakeApiCall(String, PlayFabRequestCommon, AuthType, Action`1, Action`1, Object, Dictionary`2, PlayFabAuthenticationContext, PlayFabApiSettings, IPlayFabInstanceApi) (at Assets\Libs\PlayFabSDK\Shared\Internal\PlayFabHttp\PlayFabHTTP.cs:133)
PlayFab.PlayFabClientAPI:WritePlayerEvent(WriteClientPlayerEventRequest, Action`1, Action`1, Object, Dictionary`2) (at Assets\Libs\PlayFabSDK\Client\PlayFabClientAPI.cs:2244)
```

The `www` call is being Disposed at the bottom of the class, but still results in this memory leak. `using` solved the problem for us.