### PR TITLE
Cached StringBuilder in thread-static manner for use with GetFullUrl.

### DIFF
--- a/ExampleTestProject/Assets/PlayFabSDK/Shared/Public/PlayFabSettings.cs
+++ b/ExampleTestProject/Assets/PlayFabSDK/Shared/Public/PlayFabSettings.cs
@@ -129,9 +129,23 @@ namespace PlayFab
             }
         }
 
+        [ThreadStatic]
+        private static StringBuilder _cachedStringBuilder;
+
+        private static StringBuilder AcquireStringBuilder()
+        {
+            if (_cachedStringBuilder == null)
+            {
+                _cachedStringBuilder = new StringBuilder(1000);
+            }
+
+            _cachedStringBuilder.Clear();
+            return _cachedStringBuilder;
+        }
+        
         public static string GetFullUrl(string apiCall, Dictionary<string, string> getParams, PlayFabApiSettings apiSettings = null)
         {
-            StringBuilder sb = new StringBuilder(1000);
+            StringBuilder sb = AcquireStringBuilder();
 
             string productionEnvironmentUrl = null, verticalName = null, titleId = null;
 


### PR DESCRIPTION
The SDK is unnecessarily allocating 2kb of garbage every API call for a simple URL building operation. Replaced the allocation of a new `StringBuilder` each time with a `ThreadStatic` cached string builder.